### PR TITLE
NW-1033: fix pagination rendering

### DIFF
--- a/components/Pagination/index.jsx
+++ b/components/Pagination/index.jsx
@@ -7,9 +7,17 @@ import Link from '../Link';
 
 const PageItems = ({pagesVisible, onChange, pageCount, currentPage, ...props}) => {
   let items = [];
-  const visibleEitherSide = pagesVisible / 2;
-  const minLeft = Math.floor(currentPage - visibleEitherSide);
-  const maxRight = Math.floor(currentPage + visibleEitherSide);
+  // compute minLeft and maxRight indeces of page buttons
+  // which exclude first and last pages.
+  var minLeft = currentPage - Math.floor(pagesVisible/2);
+  if (minLeft < 2) minLeft = 2;
+  var maxRight = minLeft + pagesVisible - 1;
+  if (maxRight >= pageCount) {
+    maxRight = pageCount - 1;
+    minLeft = maxRight - pagesVisible + 1;
+    if (minLeft < 2) minLeft = 2;
+  }
+  console.warn(minLeft, maxRight);
 
   for (var i = 1; i <= pageCount; i++) {
     if (
@@ -20,7 +28,7 @@ const PageItems = ({pagesVisible, onChange, pageCount, currentPage, ...props}) =
     }
 
     // If it's the min left visible, and there were skipped items
-    if (i === minLeft && (minLeft - 1) !== 1) {
+    if (i === minLeft && minLeft > 2) {
       items.push(
         <li>
           ...
@@ -39,7 +47,7 @@ const PageItems = ({pagesVisible, onChange, pageCount, currentPage, ...props}) =
     );
 
     // If it's the max right visible, and there will be skipped items
-    if (i === maxRight && (maxRight + 1) !== pageCount) {
+    if (i === maxRight && maxRight < pageCount - 1) {
       items.push(
         <li>
           ...

--- a/components/Pagination/index.jsx
+++ b/components/Pagination/index.jsx
@@ -17,7 +17,6 @@ const PageItems = ({pagesVisible, onChange, pageCount, currentPage, ...props}) =
     minLeft = maxRight - pagesVisible + 1;
     if (minLeft < 2) minLeft = 2;
   }
-  console.warn(minLeft, maxRight);
 
   for (var i = 1; i <= pageCount; i++) {
     if (

--- a/components/Pagination/index.jsx
+++ b/components/Pagination/index.jsx
@@ -9,16 +9,16 @@ const PageItems = ({pagesVisible, onChange, pageCount, currentPage, ...props}) =
   let items = [];
   // compute minLeft and maxRight indeces of page buttons
   // which exclude first and last pages.
-  var minLeft = currentPage - Math.floor(pagesVisible/2);
+  let minLeft = currentPage - Math.floor(pagesVisible/2);
   if (minLeft < 2) minLeft = 2;
-  var maxRight = minLeft + pagesVisible - 1;
+  let maxRight = minLeft + pagesVisible - 1;
   if (maxRight >= pageCount) {
     maxRight = pageCount - 1;
     minLeft = maxRight - pagesVisible + 1;
     if (minLeft < 2) minLeft = 2;
   }
 
-  for (var i = 1; i <= pageCount; i++) {
+  for (let i = 1; i <= pageCount; i++) {
     if (
       i !== 1 && i !== pageCount &&
       (i < minLeft || i > maxRight)


### PR DESCRIPTION
The pagination code has some funny edge cases....

![image](https://cloud.githubusercontent.com/assets/233158/21799255/2e801716-d764-11e6-801b-84684d96ab87.png)
![image](https://cloud.githubusercontent.com/assets/233158/21799259/3521f6f2-d764-11e6-9d61-8204464a1e06.png)
![image](https://cloud.githubusercontent.com/assets/233158/21799263/39e7ea98-d764-11e6-807d-5e078829bfb5.png)
![image](https://cloud.githubusercontent.com/assets/233158/21799264/3d331826-d764-11e6-916f-286d6c30fd9e.png)

with this fix these cases render as follows - visible is set to 5, so we always show the 1st, last and up to 5 other page numbers centred around the current page.

![image](https://cloud.githubusercontent.com/assets/233158/21800889/3d64d9e0-d76b-11e6-89a1-60a950173220.png)
![image](https://cloud.githubusercontent.com/assets/233158/21800919/53dfca86-d76b-11e6-9201-1aa4a9bafeea.png)
![image](https://cloud.githubusercontent.com/assets/233158/21800943/6a099012-d76b-11e6-86f5-6d3d4781eb09.png)
![image](https://cloud.githubusercontent.com/assets/233158/21800967/7e115ac2-d76b-11e6-83ef-b33d464cd63c.png)

